### PR TITLE
fix(BUGS-27112): Make document listeners pub in Replicator

### DIFF
--- a/src/replicator.rs
+++ b/src/replicator.rs
@@ -535,7 +535,7 @@ pub struct Replicator {
     pub headers: Option<MutableDict>,
     pub context: Option<Box<ReplicationConfigurationContext>>,
     change_listeners: ReplicatorsListeners<ReplicatorChangeListener>,
-    document_listeners: ReplicatorsListeners<ReplicatedDocumentListener>,
+    pub document_listeners: ReplicatorsListeners<ReplicatedDocumentListener>,
 }
 
 impl CblRef for Replicator {


### PR DESCRIPTION
To release a listener, we need to drop it. In order to do that, we need access to the field in the Replicator struct.