### PR TITLE
fix(BIC-1999): fix cblite version

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,7 @@ use self::c_api::{
 };
 #[cfg(target_os = "android")]
 use self::c_api::{CBLError, CBLInitContext, CBL_Init};
+use std::ffi::CStr;
 #[cfg(target_os = "android")]
 use std::ffi::CStr;
 
@@ -121,7 +122,11 @@ impl Drop for ListenerToken {
 //////// MISC. API FUNCTIONS
 
 pub fn couchbase_lite_c_version() -> String {
-    String::from_utf8_lossy(CBLITE_VERSION).to_string()
+    CStr::from_bytes_with_nul(CBLITE_VERSION)
+        .unwrap_or_default()
+        .to_str()
+        .unwrap_or_default()
+        .to_string()
 }
 
 /** Returns the total number of Couchbase Lite objects. Useful for leak checking. */

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,8 +55,6 @@ use self::c_api::{
 #[cfg(target_os = "android")]
 use self::c_api::{CBLError, CBLInitContext, CBL_Init};
 use std::ffi::CStr;
-#[cfg(target_os = "android")]
-use std::ffi::CStr;
 
 //////// RE-EXPORT:
 

--- a/tests/lib_test.rs
+++ b/tests/lib_test.rs
@@ -6,5 +6,5 @@ use couchbase_lite::*;
 
 #[test]
 fn couchbase_lite_c_version_test() {
-    assert_eq!(couchbase_lite_c_version(), "3.1.7".to_string());
+    assert_eq!(couchbase_lite_c_version(), "3.0.17".to_string());
 }

--- a/tests/lib_test.rs
+++ b/tests/lib_test.rs
@@ -1,0 +1,10 @@
+#![cfg(test)]
+
+extern crate couchbase_lite;
+
+use couchbase_lite::*;
+
+#[test]
+fn couchbase_lite_c_version_test() {
+    assert_eq!(couchbase_lite_c_version(), "3.1.7".to_string());
+}


### PR DESCRIPTION
It used to return "3.0.17\0", which created problems