### PR TITLE
Allow removing deprecated from billeo-engine

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -482,6 +482,19 @@ impl Database {
         })
     }
 
+    pub fn default_collection_or_error(&self) -> Result<Collection> {
+        let mut error = CBLError::default();
+        let collection = unsafe { CBLDatabase_DefaultCollection(self.get_ref(), &mut error) };
+
+        check_error(&error)?;
+
+        if collection.is_null() {
+            Err(Error::cbl_error(CouchbaseLiteError::NotFound))
+        } else {
+            Ok(Collection::retain(collection))
+        }
+    }
+
     //////// NOTIFICATIONS:
 
     /** Registers a database change listener function. It will be called after one or more

--- a/src/replicator.rs
+++ b/src/replicator.rs
@@ -641,20 +641,11 @@ pub extern "C" fn c_collection_property_decryptor(
 
 #[derive(Default)]
 pub struct ReplicationConfigurationContext {
-    #[deprecated(note = "please use `collection.push_filter` on default collection instead")]
-    pub push_filter: Option<ReplicationFilter>,
-    #[deprecated(note = "please use `collection.pull_filter` on default collection instead")]
-    pub pull_filter: Option<ReplicationFilter>,
-    #[deprecated(note = "please use `collection.conflict_resolver` on default collection instead")]
-    pub conflict_resolver: Option<ConflictResolver>,
-    #[deprecated(
-        note = "please use `collection_property_encryptor` on default collection instead"
-    )]
-    pub default_collection_property_encryptor: Option<DefaultCollectionPropertyEncryptor>,
-    #[deprecated(
-        note = "please use `collection_property_decryptor` on default collection instead"
-    )]
-    pub default_collection_property_decryptor: Option<DefaultCollectionPropertyDecryptor>,
+    pub push_filter: Option<ReplicationFilter>, // TODO: deprecated
+    pub pull_filter: Option<ReplicationFilter>, // TODO: deprecated
+    pub conflict_resolver: Option<ConflictResolver>, // TODO: deprecated
+    pub default_collection_property_encryptor: Option<DefaultCollectionPropertyEncryptor>, // TODO: deprecated
+    pub default_collection_property_decryptor: Option<DefaultCollectionPropertyDecryptor>, // TODO: deprecated
     pub collection_property_encryptor: Option<CollectionPropertyEncryptor>,
     pub collection_property_decryptor: Option<CollectionPropertyDecryptor>,
 }
@@ -692,11 +683,11 @@ impl ReplicationCollection {
 
 /** The configuration of a replicator. */
 pub struct ReplicatorConfiguration {
-    #[deprecated(note = "use collections instead")]
+    // TODO: deprecated
     pub database: Option<Database>, // The database to replicate. When setting the database, ONLY the default collection will be used for replication.
-    pub endpoint: Endpoint, // The address of the other database to replicate with
+    pub endpoint: Endpoint,         // The address of the other database to replicate with
     pub replicator_type: ReplicatorType, // Push, pull or both
-    pub continuous: bool,   // Continuous replication?
+    pub continuous: bool,           // Continuous replication?
     //-- Auto Purge:
     /**
     If auto purge is active, then the library will automatically purge any documents that the replicating
@@ -721,9 +712,9 @@ pub struct ReplicatorConfiguration {
     pub pinned_server_certificate: Option<Vec<u8>>, // An X.509 cert to "pin" TLS connections to (PEM or DER)
     pub trusted_root_certificates: Option<Vec<u8>>, // Set of anchor certs (PEM format)
     //-- Filtering:
-    #[deprecated(note = "please use `collection.channels` on default collection instead")]
+    // TODO: deprecated
     pub channels: MutableArray, // Optional set of channels to pull from
-    #[deprecated(note = "please use `collection.document_ids` on default collection instead")]
+    // TODO: deprecated
     pub document_ids: MutableArray, // Optional set of document IDs to replicate
     pub collections: Option<Vec<ReplicationCollection>>, // The collections to replicate with the target's endpoint (Required if the database is not set).
     //-- Advanced HTTP settings:


### PR DESCRIPTION
The function `default_collection_or_error` is useful for database calls in transactions.

Remove the `deprecated` flag inside structs that are still needed, else the deprecated warning is triggered even if the value is `None`.