### PR TITLE
Remove publish keyword in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ edition = "2024"
 license-file = "libcblite_enterprise/LICENSE.txt"
 keywords = ["couchbase"]
 categories = ["database"]
-publish = ["couchbase-lite-rust"]
 
 [dependencies]
 enum_primitive = "0.1.1"


### PR DESCRIPTION
This keyword should be added after the first publish, it is currently preventing publishing to crates.io