### PR TITLE
Bump version after logging API release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "couchbase_lite"
 description = "Rust bindings for Couchbase Lite C"
 # The first three numbers correspond to the Couchbase Lite C release, the fourth number corresponds to the Rust release
-version = "3.2.2-0"
+version = "3.2.2-1"
 
 edition = "2024"
 


### PR DESCRIPTION
No code change, bumping the version will allow other repos to use the new logging API.