### PR TITLE
chore(BLUE-129): pin actions versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install apt-get
         run: sudo apt-get install -y clang llvm
       - name: Install latest nightly
-        uses: dtolnay/rust-toolchain@v1
+        uses: dtolnay/rust-toolchain@888c2e1ea69ab0d4330cbf0af1ecc7b68f368cc1 # v1
         with:
             toolchain: nightly
             components: rustfmt, clippy


### PR DESCRIPTION
At Doctolib, we already had a strong security posture on our GitHub Actions, but following the [tj-actions repository compromission and the disclosure of CVE-2025-30066](https://www.wiz.io/blog/github-action-tj-actions-changed-files-supply-chain-attack-cve-2025-30066), we are forced to do even better! 💪 We want to pin all external GitHub Actions versions we use to a commit SHA-1 instead of a floating tag that can still be overridden by a malicious actor.

FYI, the clippy-check action used in another workflow is not present in our allowlist and thus cannot be used today. It was also deprecated by the maintainers so we might want to change that.
https://github.com/actions-rs/clippy-check