### PR TITLE
ci(EN-2854): migrate to doctolib/actions/checkout last version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,6 @@ jobs:
     steps:
       - name: Install apt-get
         run: sudo apt-get install -y clang llvm
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: doctolib/actions/checkout@429fae9c3fefa82b9a7fc0223edfaecc7234c787 # checkout-v0.1.0
       - name: Build
         run: cargo build --features=${{ matrix.version }} --verbose

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         version: [community, enterprise]
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: doctolib/actions/checkout@429fae9c3fefa82b9a7fc0223edfaecc7234c787 # checkout-v0.1.0
 
       - name: Install deps
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
         with:
             toolchain: nightly
             components: rustfmt, clippy
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: doctolib/actions/checkout@429fae9c3fefa82b9a7fc0223edfaecc7234c787 # checkout-v0.1.0
       - name: Run tests
         run: cargo test --features=${{ matrix.version }} --verbose
       - name: Run tests with Couchbase Lite C leak check


### PR DESCRIPTION
Automated migration to doctolib/actions/checkout last version