### PR TITLE
Fix critical memory safety issue in Transaction API

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -358,7 +358,7 @@ impl Database {
     /// it will be rolled back when dropped.
     ///
     /// For simpler cases, consider using `in_transaction()` instead.
-    pub fn begin_transaction(&mut self) -> Result<Transaction> {
+    pub fn begin_transaction(&self) -> Result<Transaction> {
         Transaction::new(self)
     }
 


### PR DESCRIPTION
## 🚨 Critical Memory Safety Fix

### Problem
The Transaction API had a **use-after-free vulnerability** where Transaction stored a raw `*mut CBLDatabase` pointer without ensuring the underlying Database remains alive.

**Dangerous scenario:**
```rust
let transaction = {
    let mut db = Database::open("test", None)?;
    db.begin_transaction()?  // db dropped here\!
};
transaction.commit()?; // 💥 Use-after-free\!
```

### Solution
Transaction now owns a `Database` clone instead of a raw pointer:
- `Transaction::new()` calls `db.clone()` which uses reference counting
- `Database::clone()` calls `retain()` to increment CBLDatabase ref count  
- When Transaction is dropped, Database is automatically released
- CBLDatabase stays alive for the entire Transaction lifetime

### Changes
- `Transaction.db_ref: *mut CBLDatabase` → `Transaction.db: Database`
- `Transaction::new()` takes `&Database` instead of `*mut CBLDatabase`
- All Transaction methods use `self.db.get_ref()` instead of raw pointer
- Memory safety now guaranteed through Rust's ownership system

🤖 Generated with [Claude Code](https://claude.ai/code)