### PR TITLE
refactor(build): improve version handling in build and update scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,6 @@ $ brew install bash
 ```
 
 If the script was successful:
-- Change the link `CBL_API_REFERENCE` in this README
-- Change the version in the test `couchbase_lite_c_version_test`
-- Update the version in `Cargo.toml`
 - Fix the compilation in both editions
 - Fix the tests in both editions
 - Create pull request

--- a/build.rs
+++ b/build.rs
@@ -298,26 +298,15 @@ pub fn copy_lib() -> Result<(), Box<dyn Error>> {
             let major = cbl_major_version();
             let versioned_so = format!("libcblite.so.{major}");
             fs::copy(lib_path.join(&versioned_so), dest_path.join(&versioned_so))?;
-            fs::copy(
-                lib_path.join("libicudata.so.66"),
-                dest_path.join("libicudata.so.66"),
-            )?;
-            fs::copy(
-                lib_path.join("libicui18n.so.66"),
-                dest_path.join("libicui18n.so.66"),
-            )?;
-            fs::copy(
-                lib_path.join("libicuio.so.66"),
-                dest_path.join("libicuio.so.66"),
-            )?;
-            fs::copy(
-                lib_path.join("libicutu.so.66"),
-                dest_path.join("libicutu.so.66"),
-            )?;
-            fs::copy(
-                lib_path.join("libicuuc.so.66"),
-                dest_path.join("libicuuc.so.66"),
-            )?;
+            // Copy bundled ICU libraries (version may change across CBL releases)
+            for entry in fs::read_dir(&lib_path)? {
+                let entry = entry?;
+                let name = entry.file_name();
+                let name = name.to_string_lossy();
+                if name.starts_with("libicu") && name.contains(".so.") {
+                    fs::copy(entry.path(), dest_path.join(&*name))?;
+                }
+            }
             // Needed only for build, not required for run
             fs::copy(lib_path.join(&versioned_so), dest_path.join("libcblite.so"))?;
         }

--- a/build.rs
+++ b/build.rs
@@ -28,6 +28,7 @@ extern crate fs_extra;
 use std::env;
 use std::error::Error;
 use std::fs;
+use std::io::{BufRead, BufReader};
 use std::path::PathBuf;
 use std::process::Command;
 use fs_extra::dir;
@@ -41,6 +42,31 @@ static CBL_INCLUDE_DIR: &str = "libcblite_enterprise/include";
 static CBL_LIB_DIR: &str = "libcblite_community/lib";
 #[cfg(feature = "enterprise")]
 static CBL_LIB_DIR: &str = "libcblite_enterprise/lib";
+
+/// Parses the CBL major version from CBL_Edition.h (e.g. "3" from `#define CBLITE_VERSION "3.2.4"`).
+fn cbl_major_version() -> String {
+    let header_path = PathBuf::from(CBL_INCLUDE_DIR).join("cbl/CBL_Edition.h");
+    let file = fs::File::open(&header_path)
+        .unwrap_or_else(|e| panic!("Cannot open {}: {}", header_path.display(), e));
+
+    for line in BufReader::new(file).lines() {
+        let line = line.expect("Failed to read line from CBL_Edition.h");
+        if let Some(version_str) = line
+            .strip_prefix("#define CBLITE_VERSION \"")
+            .and_then(|s| s.strip_suffix('"'))
+        {
+            return version_str
+                .split('.')
+                .next()
+                .expect("CBLITE_VERSION has no major component")
+                .to_string();
+        }
+    }
+    panic!(
+        "Could not find #define CBLITE_VERSION in {}",
+        header_path.display()
+    );
+}
 
 fn main() -> Result<(), Box<dyn Error>> {
     generate_bindings()?;
@@ -269,10 +295,9 @@ pub fn copy_lib() -> Result<(), Box<dyn Error>> {
             )?;
         }
         "linux" => {
-            fs::copy(
-                lib_path.join("libcblite.so.3"),
-                dest_path.join("libcblite.so.3"),
-            )?;
+            let major = cbl_major_version();
+            let versioned_so = format!("libcblite.so.{major}");
+            fs::copy(lib_path.join(&versioned_so), dest_path.join(&versioned_so))?;
             fs::copy(
                 lib_path.join("libicudata.so.66"),
                 dest_path.join("libicudata.so.66"),
@@ -294,19 +319,18 @@ pub fn copy_lib() -> Result<(), Box<dyn Error>> {
                 dest_path.join("libicuuc.so.66"),
             )?;
             // Needed only for build, not required for run
-            fs::copy(
-                lib_path.join("libcblite.so.3"),
-                dest_path.join("libcblite.so"),
-            )?;
+            fs::copy(lib_path.join(&versioned_so), dest_path.join("libcblite.so"))?;
         }
         "macos" => {
+            let major = cbl_major_version();
+            let versioned_dylib = format!("libcblite.{major}.dylib");
             fs::copy(
-                lib_path.join("libcblite.3.dylib"),
-                dest_path.join("libcblite.3.dylib"),
+                lib_path.join(&versioned_dylib),
+                dest_path.join(&versioned_dylib),
             )?;
             // Needed only for build, not required for run
             fs::copy(
-                lib_path.join("libcblite.3.dylib"),
+                lib_path.join(&versioned_dylib),
                 dest_path.join("libcblite.dylib"),
             )?;
         }

--- a/build.rs
+++ b/build.rs
@@ -299,6 +299,8 @@ pub fn copy_lib() -> Result<(), Box<dyn Error>> {
             let versioned_so = format!("libcblite.so.{major}");
             fs::copy(lib_path.join(&versioned_so), dest_path.join(&versioned_so))?;
             // Copy bundled ICU libraries (version may change across CBL releases)
+            // WARNING: ICU libs are vendored manually, not from Couchbase packages.
+            // When upgrading to a new CBL major version, verify that the ICU version is still compatible.
             for entry in fs::read_dir(&lib_path)? {
                 let entry = entry?;
                 let name = entry.file_name();

--- a/c_playground/CMakeLists.txt
+++ b/c_playground/CMakeLists.txt
@@ -6,4 +6,5 @@ include_directories(${CMAKE_SOURCE_DIR}/../libcblite_enterprise/include)
 
 add_executable(Main main.c)
 
-target_link_libraries(Main PUBLIC ${CMAKE_SOURCE_DIR}/../libcblite_enterprise/lib/macos/libcblite.3.dylib)
+file(GLOB CBLITE_LIB "${CMAKE_SOURCE_DIR}/../libcblite_enterprise/lib/macos/libcblite.*.dylib")
+target_link_libraries(Main PUBLIC ${CBLITE_LIB})

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -114,7 +114,7 @@ impl Blob {
     }
 
     /// Opens a stream for reading a blob's content from disk.
-    pub fn open_content(&self) -> Result<BlobReader> {
+    pub fn open_content(&self) -> Result<BlobReader<'_>> {
         check_ptr(
             |err| unsafe { CBLBlob_OpenContentStream(self.get_ref(), err) },
             |stream| BlobReader {

--- a/src/error.rs
+++ b/src/error.rs
@@ -249,10 +249,10 @@ impl Error {
 
     /// Returns a message describing an error.
     pub fn message(&self) -> String {
-        if let ErrorCode::CouchbaseLite(e) = self.code {
-            if e == CouchbaseLiteError::UntranslatableError {
-                return "Unknown error".to_string();
-            }
+        if let ErrorCode::CouchbaseLite(e) = self.code
+            && e == CouchbaseLiteError::UntranslatableError
+        {
+            return "Unknown error".to_string();
         }
         unsafe {
             CBLError_Message(&self.as_cbl_error())

--- a/src/fleece_mutable.rs
+++ b/src/fleece_mutable.rs
@@ -96,7 +96,7 @@ impl MutableArray {
         unsafe { FLMutableArray_IsChanged(self.get_ref()) }
     }
 
-    pub fn at(&mut self, index: u32) -> Option<Slot> {
+    pub fn at(&mut self, index: u32) -> Option<Slot<'_>> {
         if self.count() > index {
             Some(unsafe {
                 Slot {
@@ -109,7 +109,7 @@ impl MutableArray {
         }
     }
 
-    pub fn append(&mut self) -> Slot {
+    pub fn append(&mut self) -> Slot<'_> {
         unsafe {
             Slot {
                 cbl_ref: FLMutableArray_Append(self.get_ref()),

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -72,7 +72,21 @@ impl Drop for LeakChecker {
     fn drop(&mut self) {
         if self.is_checking {
             println!("Checking if Couchbase Lite objects were leaked by this test");
-            self.end_instance_count = instance_count();
+
+            // Poll instance_count() briefly to allow the C library to finish
+            // async cleanup of internal objects (e.g. replicator network connections).
+            let max_wait = time::Duration::from_secs(5);
+            let poll_interval = time::Duration::from_millis(100);
+            let start = time::Instant::now();
+            loop {
+                self.end_instance_count = instance_count();
+                if self.end_instance_count == self.start_instance_count
+                    || start.elapsed() >= max_wait
+                {
+                    break;
+                }
+                thread::sleep(poll_interval);
+            }
 
             if self.start_instance_count != self.end_instance_count {
                 println!("Leaks detected :-(");

--- a/update_cblite_c.sh
+++ b/update_cblite_c.sh
@@ -287,5 +287,18 @@ done
 
 rm -rf $tmpFolder
 
+# ############################# #
+# Update version references     #
+# ############################# #
+
+echoGreen "Update version references"
+
+sed -i '' "s/^version = \".*\"/version = \"${version}-0\"/" Cargo.toml
+sed -i '' "s/couchbase_lite_c_version(), \".*\"/couchbase_lite_c_version(), \"${version}\"/" tests/lib_test.rs
+sed -i '' "s|mobile/[0-9]*\.[0-9]*\.[0-9]*/couchbase-lite-c|mobile/${version}/couchbase-lite-c|" README.md
+
+echoGreen "Version references updated"
+echo
+
 echoGreen "All good :-)"
 echoGreen "Next steps: build OK, tests OK & create a pull request"

--- a/update_cblite_c.sh
+++ b/update_cblite_c.sh
@@ -179,8 +179,8 @@ do
                 libDestinationFile="${platformFolder}/libcblite.so.${major_version}"
                 cp $libFile $libDestinationFile
 
-                # Copy required ICU libs from the newly downloaded package
-                cp ${unzipPlatformFolder}/libcblite-${version}/lib/x86_64-linux-gnu/libicu* $platformFolder
+                # There are required ICU libs already present in the existing package
+                cp libcblite_$variant/lib/x86_64-unknown-linux-gnu/libicu* $platformFolder
 
                 ;;
 

--- a/update_cblite_c.sh
+++ b/update_cblite_c.sh
@@ -180,6 +180,8 @@ do
                 cp $libFile $libDestinationFile
 
                 # There are required ICU libs already present in the existing package
+                # WARNING: ICU libs are NOT included in Couchbase Lite C packages and must be vendored manually.
+                # When upgrading to a new CBL major version, verify that the ICU version is still compatible.
                 cp libcblite_$variant/lib/x86_64-unknown-linux-gnu/libicu* $platformFolder
 
                 ;;

--- a/update_cblite_c.sh
+++ b/update_cblite_c.sh
@@ -67,6 +67,8 @@ else
   echo
 fi
 
+major_version="${version%%.*}"
+
 tmpFolder=$(mktemp -d)
 echo "Temporary directory ${tmpFolder}"
 echo
@@ -174,11 +176,11 @@ do
                 mkdir $platformFolder
 
                 libFile="${unzipPlatformFolder}/libcblite-${version}/lib/x86_64-linux-gnu/libcblite.so.${version}"
-                libDestinationFile="${platformFolder}/libcblite.so.3"
+                libDestinationFile="${platformFolder}/libcblite.so.${major_version}"
                 cp $libFile $libDestinationFile
 
-                # There are required ICU libs already present in the existing package
-                cp libcblite_$variant/lib/x86_64-unknown-linux-gnu/libicu* $platformFolder
+                # Copy required ICU libs from the newly downloaded package
+                cp ${unzipPlatformFolder}/libcblite-${version}/lib/x86_64-linux-gnu/libicu* $platformFolder
 
                 ;;
 
@@ -199,7 +201,7 @@ do
                 mkdir $platformFolder
 
                 libFile="${unzipPlatformFolder}/libcblite-${version}/lib/libcblite.${version}.dylib"
-                libDestinationFile="${platformFolder}/libcblite.3.dylib"
+                libDestinationFile="${platformFolder}/libcblite.${major_version}.dylib"
                 cp $libFile $libDestinationFile
 
                 ;;


### PR DESCRIPTION
## Context

Preparation for upgrading from Couchbase Lite C SDK 3.x to 4.x. The build infrastructure hardcoded the major version "3" in multiple places, which would cause silent build failures when vendoring 4.x libraries. Validated by running `update_cblite_c.sh` with both 3.2.3 and 4.0.3.

## Changes

- **build.rs**: Derive CBL major version from `CBL_Edition.h` at build time instead of hardcoding "3" in library filenames (`libcblite.so.3`, `libcblite.3.dylib`). Replace hardcoded ICU `.so.66` copies with dynamic directory iteration.
- **update_cblite_c.sh**: Extract major version from the `-v` argument and use it for destination filenames. Automate version updates in `Cargo.toml`, `tests/lib_test.rs`, and `README.md` at the end of the script.
- **c_playground/CMakeLists.txt**: Replace hardcoded `libcblite.3.dylib` with a glob pattern.

## Test plan

- [x] `cargo build` (community + enterprise)
- [x] `cargo clippy -- -D warnings`
- [x] `./update_cblite_c.sh -v 3.2.3` — script succeeds, build compiles
- [x] `./update_cblite_c.sh -v 4.0.3` — script succeeds, correct library naming (`libcblite.so.4`, `libcblite.4.dylib`)
- [x] CI green (build, clippy, tests — community + enterprise)

## Boy scouting

- Fix flaky `conflict_resolver` / `conflict_resolver_save_keep_local` tests caused by a race between CBL's async object cleanup and the leak checker.
- Pre-existing clippy fixes (elided lifetimes, collapsible if).